### PR TITLE
feat: Improve login method to use cookies instead of headers

### DIFF
--- a/backend/src/main/java/io/blog/devlog/domain/user/dto/ResponseUserProfileDto.java
+++ b/backend/src/main/java/io/blog/devlog/domain/user/dto/ResponseUserProfileDto.java
@@ -1,0 +1,23 @@
+package io.blog.devlog.domain.user.dto;
+
+import io.blog.devlog.domain.user.model.Role;
+import io.blog.devlog.domain.user.model.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseUserProfileDto {
+    private String username;
+    private String email;
+    private String profileUrl;
+    private Role role;
+
+    public static ResponseUserProfileDto of(User user) {
+        return new ResponseUserProfileDto(user.getUsername(), user.getEmail(), user.getProfileUrl(), user.getRole());
+    }
+}

--- a/backend/src/main/java/io/blog/devlog/global/login/filter/AuthenticationProcessingFilter.java
+++ b/backend/src/main/java/io/blog/devlog/global/login/filter/AuthenticationProcessingFilter.java
@@ -47,6 +47,10 @@ public class AuthenticationProcessingFilter extends OncePerRequestFilter {
                 }
             }
             catch (ExpiredJwtException e) {
+                if (request.getRequestURI().equals("/reissue")) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
                 Integer status = HttpServletResponse.SC_UNAUTHORIZED;
                 String path = request.getRequestURI();
                 errorResponse.setResponse(response, status, e.getMessage(), path);

--- a/backend/src/main/java/io/blog/devlog/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/io/blog/devlog/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -6,6 +6,7 @@ import io.blog.devlog.global.jwt.service.JwtService;
 import io.blog.devlog.global.login.dto.PrincipalDetails;
 import io.blog.devlog.global.response.SuccessResponse;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -66,7 +67,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 //        userService.updateRefreshToken(user, refreshToken);
         user.updateRefreshToken(refreshToken);
 
-        response.sendRedirect(String.format("%s/callback?at=%s&rt=%s", frontendOriginUrl, accessToken, refreshToken));
+        response.sendRedirect(String.format("%s/callback", frontendOriginUrl));
+//        response.sendRedirect(String.format("%s/callback?at=%s&rt=%s", frontendOriginUrl, accessToken, refreshToken));
         return true;
     }
 }

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -45,6 +45,7 @@ jwt:
 
 frontend:
   url: http://localhost:3000
+  domain: localhost
 
 file:
   upload:

--- a/backend/src/main/resources/yaml/application-dev.yml
+++ b/backend/src/main/resources/yaml/application-dev.yml
@@ -21,6 +21,7 @@ spring:
         format_sql: true
 frontend:
   url: http://localhost:3000
+  domain: localhost
 file:
   upload:
     path: C:\Programming\Blog\devlog\backend\src\main\resources\upload

--- a/backend/src/main/resources/yaml/application-docker.yml
+++ b/backend/src/main/resources/yaml/application-docker.yml
@@ -22,6 +22,7 @@ spring:
         hightlight_sql: true
 frontend:
   url: http://localhost:3000
+  domain: localhost
 file:
   upload:
     path: C:\Programming\Blog\devlog\backend\src\main\resources\upload

--- a/backend/src/main/resources/yaml/application-local.yml
+++ b/backend/src/main/resources/yaml/application-local.yml
@@ -22,6 +22,7 @@ spring:
         hightlight_sql: true
 frontend:
   url: http://localhost:3000
+  domain: localhost
 file:
   upload:
     path: C:\Programming\Blog\devlog\backend\src\main\resources\upload

--- a/backend/src/main/resources/yaml/application-prod.yml
+++ b/backend/src/main/resources/yaml/application-prod.yml
@@ -20,6 +20,7 @@ spring:
         format_sql: true
 frontend:
   url: https://devlog.run
+  domain: devlog.run
 file:
   upload:
     path: /home/resource

--- a/backend/src/test/java/io/blog/devlog/config/TestConfig.java
+++ b/backend/src/test/java/io/blog/devlog/config/TestConfig.java
@@ -45,6 +45,7 @@ public class TestConfig {
         ReflectionTestUtils.setField(jwtService, "refreshHeader", "Authorization-Refresh");
         ReflectionTestUtils.setField(jwtService, "accessTokenExpiration", 3600);
         ReflectionTestUtils.setField(jwtService, "refreshTokenExpiration", 86400);
+        ReflectionTestUtils.setField(jwtService, "frontendDomain", "localhost");
         jwtService.init();
         return jwtService;
     }

--- a/frontend/src/api/Axios.js
+++ b/frontend/src/api/Axios.js
@@ -1,17 +1,11 @@
 import axios from "axios";
 import { authAtom } from "../recoil/authAtom";
 import { useRecoilState } from "recoil";
-import { getCookie } from "../utils/hooks/useCookie";
 import { jwt_refresh_api } from "./User";
-import {
-  ACCESS_TOKEN_STRING,
-  REFRESH_TOKEN_STRING,
-} from "constants/user/login";
 import { useNavigate } from "react-router-dom";
 import { warnSignOut } from "utils/authenticate";
 import { useEffect } from "react";
 import throttle from "lodash.throttle";
-import { decodeJWT } from "utils/hooks/useJWT";
 
 const REFRESH_URL = "/reissue";
 
@@ -20,31 +14,31 @@ export const API = axios.create({
   withCredentials: true,
 });
 
-const refreshAccessToken = async (refreshToken) => {
-  const paylaod = decodeJWT(refreshToken);
-  try {
-    return await jwt_refresh_api(paylaod.email);
-  } catch (error) {
-    console.error("Failed to refresh access token:", error);
-    return false;
-  }
-};
+// const refreshAccessToken = async (refreshToken) => {
+//   const paylaod = decodeJWT(refreshToken);
+//   try {
+//     return await jwt_refresh_api(paylaod.email);
+//   } catch (error) {
+//     console.error("Failed to refresh access token:", error);
+//     return false;
+//   }
+// };
 
-const requestAuthTokenInjector = async (requestConfig) => {
-  // if (!requestConfig.headers) return requestConfig;
-  let token = getCookie(ACCESS_TOKEN_STRING);
-  const refreshToken = getCookie(REFRESH_TOKEN_STRING);
-  if (requestConfig.url !== REFRESH_URL) {
-    if (!token && refreshToken) {
-      token = await refreshAccessToken(refreshToken);
-    }
+const requestAuthTokenInjector = async (request) => {
+  // if (!request.headers) return request;
+  // let token = getCookie(ACCESS_TOKEN_STRING);
+  // const refreshToken = getCookie(REFRESH_TOKEN_STRING);
+  // if (request.url !== REFRESH_URL) {
+  //   if (!token && refreshToken) {
+  //     token = await refreshAccessToken(refreshToken);
+  //   }
 
-    if (token) requestConfig.headers["Authorization"] = "Bearer " + token;
-  } else {
-    // if (!refreshToken) return Promise.reject("No refresh token");
-    requestConfig.headers["Authorization"] = "Bearer " + refreshToken;
-  }
-  return requestConfig;
+  //   if (token) request.headers["Authorization"] = "Bearer " + token;
+  // } else {
+  //   // if (!refreshToken) return Promise.reject("No refresh token");
+  //   request.headers["Authorization"] = "Bearer " + refreshToken;
+  // }
+  return request;
 };
 
 const responseSuccessHandler = (response) => {

--- a/frontend/src/api/User.js
+++ b/frontend/src/api/User.js
@@ -1,6 +1,5 @@
 import mem from "mem";
 import { API } from "./Axios";
-import { reissueToken } from "utils/authenticate";
 import { REFRESH_STORE } from "./Cache";
 
 export const user_join_api = async (username, password, email) => {
@@ -36,13 +35,26 @@ export const user_check_api = async () => {
     });
 };
 
+export const user_profile_api = async () => {
+  return await API.get("/profile")
+    .then((response) => response)
+    .catch((error) => {
+      throw error;
+    });
+};
+
+export const user_logout_api = async () => {
+  return await API.get("/signout")
+    .then((response) => response)
+    .catch((error) => {
+      throw error;
+    });
+};
+
 export const jwt_refresh_api = mem(
-  async (email) => {
+  async (email = null) => {
     return await API.get("/reissue")
-      .then((response) => {
-        console.log(response);
-        return reissueToken(response.headers);
-      })
+      .then((response) => response)
       .catch((error) => {
         throw error;
       });

--- a/frontend/src/components/base/userLogin/login/Login.jsx
+++ b/frontend/src/components/base/userLogin/login/Login.jsx
@@ -33,9 +33,7 @@ function Login() {
     user_login_api(email, password)
       .then(async (res) => {
         console.log(res);
-        const access_token = res.headers["authorization"];
-        const refresh_token = res.headers["authorization-refresh"];
-        await signIn(access_token, refresh_token, setAuthDto);
+        await signIn(setAuthDto);
         if (backpath) {
           navigate(backpath);
         } else {

--- a/frontend/src/pages/Callback.jsx
+++ b/frontend/src/pages/Callback.jsx
@@ -1,19 +1,21 @@
 import React, { useEffect } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useRecoilState } from "recoil";
 import { authAtom } from "recoil/authAtom";
 import { signIn } from "utils/authenticate";
 
 function Callback() {
   const navigate = useNavigate();
-  const location = useLocation();
+  // const location = useLocation();
   const [, setAuthDto] = useRecoilState(authAtom);
 
   useEffect(() => {
-    const searchParams = new URLSearchParams(location.search);
-    const access_token = searchParams.get("at");
-    const refresh_token = searchParams.get("rt");
-    signIn(access_token, refresh_token, setAuthDto);
+    // const searchParams = new URLSearchParams(location.search);
+    // const access_token = searchParams.get("at");
+    // const refresh_token = searchParams.get("rt");
+    // signIn(access_token, refresh_token, setAuthDto);
+    const res = signIn(setAuthDto);
+    console.log("callback", res);
     navigate("/");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/frontend/src/recoil/authAtom.js
+++ b/frontend/src/recoil/authAtom.js
@@ -7,11 +7,18 @@ import { atom } from "recoil";
 // });
 
 export class Auth {
-  constructor(username = null, email = null, isLogin = false, role = "GUEST") {
+  constructor(
+    username = null,
+    email = null,
+    isLogin = false,
+    role = "GUEST",
+    profileUrl = null
+  ) {
     this.username = username;
     this.email = email;
     this.isLogin = isLogin;
     this.role = role;
+    this.profileUrl = profileUrl;
   }
 }
 


### PR DESCRIPTION
## 로그인 방식 개선

1. OAuth 2.0의 경우, 백엔드에서 JWT를 전달할 때, url 파라미터로 보내서 보안 위험이 있었음.
2. 유저 정보를 JWT가 담긴 쿠키를 읽어와서 체크했음. > 그로 인해, HttpOnly를 활성화 할 수 없었고, `XSS 취약점` 발생.
3. 위의 문제들을 개선하기 위해 백엔드에서 JWT를 전달할 때 response에 setCookie 형태로 제공.
4. JWT는 HttpOnly를 활성화한 상태로 보내고, 클라이언트에서 유저 정보를 얻을 땐 백엔드에 요청하는 구조로 변경.
5. 로그아웃시에도 백엔드에게 요청하여 쿠키의 maxAge를 0으로 하여, 자동으로 사라지게 함.