### PR TITLE
feat: Add profile picture upload

### DIFF
--- a/backend/main-service/src/main/java/io/blog/devlog/domain/file/dto/FileDto.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/file/dto/FileDto.java
@@ -5,6 +5,7 @@ import io.blog.devlog.domain.file.model.EntityType;
 import io.blog.devlog.domain.file.model.File;
 import io.blog.devlog.domain.file.model.FileType;
 import io.blog.devlog.domain.post.model.Post;
+import io.blog.devlog.domain.user.model.User;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AllArgsConstructor;
@@ -43,6 +44,10 @@ public class FileDto {
 
     public File toEntity(Comment comment) {
         return this.toEntity().setEntity(EntityType.COMMENT, comment.getId());
+    }
+
+    public File toEntity(User user) {
+        return this.toEntity().setEntity(EntityType.USER, user.getId());
     }
 
     public static FileDto of(File file) {

--- a/backend/main-service/src/main/java/io/blog/devlog/domain/file/model/File.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/file/model/File.java
@@ -17,6 +17,7 @@ public class File extends CreateTime {
     private Long id;
     private String fileName;
     private long fileSize;
+    @Column(unique = true)
     private String fileUrl; // year/month/day/fileName
     private String filePath; // res
     @Enumerated(EnumType.STRING)

--- a/backend/main-service/src/main/java/io/blog/devlog/domain/post/controller/PostController.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/post/controller/PostController.java
@@ -13,6 +13,7 @@ import io.blog.devlog.domain.post.service.PostViewsService;
 import io.blog.devlog.domain.user.model.Role;
 import io.blog.devlog.domain.user.model.User;
 import io.blog.devlog.domain.user.service.UserService;
+import io.blog.devlog.domain.views.service.PostViewCountService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +41,7 @@ public class PostController {
     private final PostLikeService postLikeService;
     private final PostUploadService postUploadService;
     private final PostViewsService postViewsService;
+    private final PostViewCountService postViewCountService;
 
     @PostMapping
     public void uploadPost(@RequestBody RequestPostDto requestPostDto) throws BadRequestException {
@@ -83,7 +85,10 @@ public class PostController {
                     .build();
         }
         PostDetail postDetail = postService.getPostByUrl(url, user);
-        postViewsService.increaseViewCount(postDetail.getPost().getId(), request);
+        boolean increased = postViewsService.increaseViewCount(postDetail.getPost().getId(), request);
+        if (increased) {
+            postViewCountService.increaseViewCount(postDetail.getPost().getId());
+        }
         List<ResponseCommentDto> comments = commentService.getCommentsFromPost(user, postDetail);
         PostLikeDetail postLikeDetail = postLikeService.likeDetailFromPost(postDetail.getPost(), user);
         return ResponseEntity.ok(ResponsePostCommentDto.of(email, postDetail, comments, postLikeDetail));

--- a/backend/main-service/src/main/java/io/blog/devlog/domain/post/service/PostViewsService.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/post/service/PostViewsService.java
@@ -4,5 +4,5 @@ import io.blog.devlog.domain.user.model.User;
 import jakarta.servlet.http.HttpServletRequest;
 
 public interface PostViewsService {
-    public void increaseViewCount(Long postId, HttpServletRequest request);
+    public boolean increaseViewCount(Long postId, HttpServletRequest request);
 }

--- a/backend/main-service/src/main/java/io/blog/devlog/domain/post/service/PostViewsServiceImpl.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/post/service/PostViewsServiceImpl.java
@@ -4,7 +4,6 @@ import io.blog.devlog.domain.post.model.PostViews;
 import io.blog.devlog.domain.post.model.PostViewsId;
 import io.blog.devlog.domain.post.repository.PostRepository;
 import io.blog.devlog.domain.post.repository.PostViewsRepository;
-import io.blog.devlog.domain.user.model.User;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,12 +17,12 @@ import java.sql.Timestamp;
 @Transactional
 @Slf4j
 public class PostViewsServiceImpl implements PostViewsService {
-    private final Long perViewCount = 1000*60*60L; // 1 hour
+    private final Long PER_VIEW_COUNT = 1000*60*60L; // 1 hour
     private final PostViewsRepository postViewsRepository;
     private final PostRepository postRepository;
 
     @Override
-    public void increaseViewCount(Long postId, HttpServletRequest request) {
+    public boolean increaseViewCount(Long postId, HttpServletRequest request) {
         String clientIP = request.getRemoteAddr();
         if (request.getHeader("X-Forwarded-For") != null) {
             clientIP = request.getHeader("X-Forwarded-For").split(",")[0];
@@ -31,8 +30,8 @@ public class PostViewsServiceImpl implements PostViewsService {
 
         PostViews postViews = postViewsRepository.findById(new PostViewsId(postId, clientIP)).orElse(null);
         Timestamp now = new Timestamp(System.currentTimeMillis());
-        if (postViews != null && postViews.getViewsAt().getTime() + perViewCount > now.getTime()) {
-            return;
+        if (postViews != null && postViews.getViewsAt().getTime() + PER_VIEW_COUNT > now.getTime()) {
+            return false;
         }
         if (postViews == null) {
             postViews = PostViews.builder()
@@ -44,5 +43,6 @@ public class PostViewsServiceImpl implements PostViewsService {
         }
         postViewsRepository.save(postViews);
         postRepository.increasePostView(postId);
+        return true;
     }
 }

--- a/backend/main-service/src/main/java/io/blog/devlog/domain/user/controller/ProfileController.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/user/controller/ProfileController.java
@@ -1,0 +1,105 @@
+package io.blog.devlog.domain.user.controller;
+
+import io.blog.devlog.domain.file.service.FileService;
+import io.blog.devlog.domain.user.dto.RequestPasswordDto;
+import io.blog.devlog.domain.user.dto.RequestProfileUrlDto;
+import io.blog.devlog.domain.user.dto.ResponseUserProfileDto;
+import io.blog.devlog.domain.user.model.User;
+import io.blog.devlog.domain.user.service.UserService;
+import io.blog.devlog.domain.user.service.VerifyService;
+import io.blog.devlog.global.redis.message.VerifyEmailMessage;
+import io.blog.devlog.global.redis.service.VerifyEmailPubService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.BadRequestException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static io.blog.devlog.global.utils.SecurityUtils.getUserEmail;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/profile")
+public class ProfileController {
+    private final FileService fileService;
+    private final UserService userService;
+    private final VerifyService verifyService;
+    private final VerifyEmailPubService verifyEmailPubService;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @GetMapping
+    public ResponseEntity<ResponseUserProfileDto> getProfile() throws BadRequestException {
+        String userEmail = getUserEmail();
+        if (userEmail == null) throw new BadRequestException("로그인이 필요합니다.");
+        log.info("GET /profile userEmail : {}", userEmail);
+        User user = userService.getUserByEmail(userEmail).orElseThrow(() -> new BadRequestException("잘못된 요청입니다."));
+        return ResponseEntity.ok(ResponseUserProfileDto.of(user));
+    }
+
+    @PutMapping("/password")
+    public void renewPassword(@RequestBody RequestPasswordDto requestPasswordDto) throws BadRequestException {
+        log.info("PUT /password/renew RequestPasswordDto : {}", requestPasswordDto);
+
+        if (requestPasswordDto.getCurrentPassword().isEmpty() || requestPasswordDto.getNewPassword().isEmpty()) {
+            throw new BadRequestException("잘못된 요청입니다.");
+        }
+        if (requestPasswordDto.getCurrentPassword().equals(requestPasswordDto.getNewPassword())) {
+            throw new BadRequestException("기존 비밀번호와 새 비밀번호가 같습니다.");
+        }
+        String userEmail = getUserEmail();
+        if (userEmail == null) {
+            throw new BadRequestException("잘못된 요청입니다.");
+        }
+        User user = userService.getUserByEmail(userEmail).orElseThrow(() -> new BadRequestException("잘못된 요청입니다."));
+
+        user.updatePassword(bCryptPasswordEncoder, requestPasswordDto);
+        userService.saveUser(user);
+    }
+
+    @GetMapping("/verify-email")
+    public void requestVerifyEmail() {
+        String email = getUserEmail();
+        String code = verifyService.createVerifyCode(email);
+        VerifyEmailMessage verifyEmailMessage = new VerifyEmailMessage(email, "[devLog] 이메일 인증 코드", code);
+
+        verifyEmailPubService.sendVerifyEmail(verifyEmailMessage);
+    }
+
+    @PostMapping("/verify-email/{code}")
+    public void sendVerifyEmail(@PathVariable String code) throws BadRequestException {
+        String email = getUserEmail();
+        if (!verifyService.checkVerifyCode(email, code)) {
+            throw new BadRequestException("이메일 인증에 실패했습니다.");
+        }
+
+        User user = userService.getUserByEmail(email).orElseThrow(() -> new BadRequestException("잘못된 요청입니다."));
+        user.certified();
+        userService.saveUser(user);
+    }
+
+    @PostMapping("/picture")
+    public void updateProfileUrl(@RequestBody RequestProfileUrlDto requestProfileUrlDto) throws BadRequestException {
+        String email = getUserEmail();
+        User user = userService.getUserByEmail(email).orElseThrow(() -> new BadRequestException("잘못된 요청입니다."));
+        fileService.getFileByUserId(user.getId()).ifPresent(
+                file -> fileService.deleteFileFromUser(user)
+        );
+        fileService.uploadFileAndDeleteTempFile(user, List.of(requestProfileUrlDto.getFile()));
+        fileService.deleteTempFiles();
+        userService.updateProfileUrl(email, requestProfileUrlDto.getProfileUrl());
+    }
+
+    @DeleteMapping("/picture")
+    public void deleteProfileUrl() throws BadRequestException {
+        String email = getUserEmail();
+        User user = userService.getUserByEmail(email).orElseThrow(() -> new BadRequestException("잘못된 요청입니다."));
+        fileService.getFileByUserId(user.getId()).ifPresent(
+                file -> fileService.deleteFileFromUser(user)
+        );
+        userService.updateProfileUrl(email, null);
+    }
+}

--- a/backend/main-service/src/main/java/io/blog/devlog/domain/user/dto/RequestProfileUrlDto.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/user/dto/RequestProfileUrlDto.java
@@ -1,0 +1,16 @@
+package io.blog.devlog.domain.user.dto;
+
+import io.blog.devlog.domain.file.dto.FileDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestProfileUrlDto {
+    private FileDto file;
+    private String profileUrl;
+}

--- a/backend/main-service/src/main/java/io/blog/devlog/domain/user/repository/UserRepository.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/user/repository/UserRepository.java
@@ -19,4 +19,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     public Optional<User> findByEmail(String email);
 //    public Optional<User> findByRefreshToken(String refreshToken);
     public List<User> findAllByRole(Role role);
+    @Modifying
+    @Query("update User u set u.profileUrl = :profileUrl where u.email = :email")
+    public void updateProfileUrl(String email, String profileUrl);
 }

--- a/backend/main-service/src/main/java/io/blog/devlog/domain/user/service/UserService.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/user/service/UserService.java
@@ -69,4 +69,8 @@ public class UserService {
     public boolean isAdmin(User user) {
         return user.getRole() == Role.ADMIN;
     }
+
+    public void updateProfileUrl(String email, String profileUrl) {
+        userRepository.updateProfileUrl(email, profileUrl);
+    }
 }

--- a/backend/main-service/src/main/java/io/blog/devlog/domain/views/controller/PostViewCountController.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/views/controller/PostViewCountController.java
@@ -1,0 +1,31 @@
+package io.blog.devlog.domain.views.controller;
+
+import io.blog.devlog.domain.views.dto.ResponsePostViewCountDto;
+import io.blog.devlog.domain.views.service.PostViewCountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/views/post")
+@RequiredArgsConstructor
+public class PostViewCountController {
+    private final PostViewCountService postViewCountService;
+
+    @GetMapping("/{postId}/daily")
+    public List<ResponsePostViewCountDto> getDailyPostViewCount(@PathVariable Long postId, @RequestParam String start, @RequestParam String end) {
+        return postViewCountService.getDailyPostViewCount(postId, start, end);
+    }
+
+    @GetMapping("/{postId}/monthly")
+    public List<ResponsePostViewCountDto> getMonthlyPostViewCount(@PathVariable Long postId, @RequestParam String start, @RequestParam String end) {
+        return postViewCountService.getMonthlyPostViewCount(postId, start, end);
+    }
+
+    @GetMapping("/{postId}/yearly")
+    public List<ResponsePostViewCountDto> getYearlyPostViewCount(@PathVariable Long postId, @RequestParam String start, @RequestParam String end) {
+        return postViewCountService.getYearlyPostViewCount(postId, start, end);
+    }
+}

--- a/backend/main-service/src/main/java/io/blog/devlog/domain/views/dto/ResponsePostViewCountDto.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/views/dto/ResponsePostViewCountDto.java
@@ -1,0 +1,55 @@
+package io.blog.devlog.domain.views.dto;
+
+import io.blog.devlog.domain.views.model.PostViewCount;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponsePostViewCountDto {
+    private Long postId;
+    private String viewDate;
+    private int viewCount;
+
+    public static ResponsePostViewCountDto of(PostViewCount postViewCount) {
+        return ResponsePostViewCountDto.builder()
+                .postId(postViewCount.getPostId())
+                .viewDate(postViewCount.getViewDate().toString())
+                .viewCount(postViewCount.getViewCount())
+                .build();
+    }
+
+    public static ResponsePostViewCountDto ofDailyView(Long postId, Object[] dailyView) {
+        LocalDate localDate = (LocalDate) dailyView[0];
+        Long viewCount = (Long) dailyView[1];
+        return ResponsePostViewCountDto.builder()
+                .postId(postId)
+                .viewDate(localDate.toString())
+                .viewCount(viewCount.intValue())
+                .build();
+    }
+
+    public static ResponsePostViewCountDto ofMonthlyView(Long postId, Object[] monthlyView) {
+        Long viewCount = (Long) monthlyView[2];
+        return ResponsePostViewCountDto.builder()
+                .postId(postId)
+                .viewDate(String.format("%d-%02d", (int) monthlyView[0], (int) monthlyView[1]))
+                .viewCount(viewCount.intValue())
+                .build();
+    }
+
+    public static ResponsePostViewCountDto ofYearlyView(Long postId, Object[] yearlyView) {
+        Long viewCount = (Long) yearlyView[1];
+        return ResponsePostViewCountDto.builder()
+                .postId(postId)
+                .viewDate(String.format("%d", (int) yearlyView[0]))
+                .viewCount(viewCount.intValue())
+                .build();
+    }
+}

--- a/backend/main-service/src/main/java/io/blog/devlog/domain/views/model/PostViewCount.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/views/model/PostViewCount.java
@@ -1,0 +1,36 @@
+package io.blog.devlog.domain.views.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.LocalDate;
+
+@Table(name="POSTVIEWCOUNT", indexes = {
+        @Index(name = "idx_post", columnList = "post_id, view_date"),
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Getter
+@Builder
+@ToString
+public class PostViewCount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long postId;
+    private LocalDate viewDate;
+    @ColumnDefault("0")
+    private int viewCount;
+
+    public PostViewCount(Long postId, LocalDate viewDate, int viewCount) {
+        this.postId = postId;
+        this.viewDate = viewDate;
+        this.viewCount = viewCount;
+    }
+
+    public void increaseViewCount() {
+        this.viewCount += 1;
+    }
+}

--- a/backend/main-service/src/main/java/io/blog/devlog/domain/views/repository/PostViewCountRepository.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/views/repository/PostViewCountRepository.java
@@ -1,0 +1,34 @@
+package io.blog.devlog.domain.views.repository;
+
+import io.blog.devlog.domain.views.model.PostViewCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PostViewCountRepository extends JpaRepository<PostViewCount, Long> {
+    Optional<PostViewCount> findByPostIdAndViewDate(Long postId, LocalDate viewDate);
+
+    // 일별 조회수 조회
+    @Query("SELECT pvc.viewDate, SUM(pvc.viewCount) FROM PostViewCount pvc " +
+            "WHERE pvc.postId = :postId AND pvc.viewDate BETWEEN :startDate AND :endDate " +
+            "GROUP BY pvc.viewDate")
+    List<Object[]> findDailyViews(@Param("postId") Long postId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
+    // 월별 조회수 조회
+    @Query("SELECT YEAR(pvc.viewDate), MONTH(pvc.viewDate), SUM(pvc.viewCount) FROM PostViewCount pvc " +
+            "WHERE pvc.postId = :postId AND pvc.viewDate BETWEEN :startDate AND :endDate " +
+            "GROUP BY YEAR(pvc.viewDate), MONTH(pvc.viewDate)")
+    List<Object[]> findMonthlyViews(@Param("postId") Long postId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
+    // 연도별 조회수 조회
+    @Query("SELECT YEAR(pvc.viewDate), SUM(pvc.viewCount) FROM PostViewCount pvc " +
+            "WHERE pvc.postId = :postId AND pvc.viewDate BETWEEN :startDate AND :endDate " +
+            "GROUP BY YEAR(pvc.viewDate)")
+    List<Object[]> findYearlyViews(@Param("postId") Long postId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+}

--- a/backend/main-service/src/main/java/io/blog/devlog/domain/views/service/PostViewCountService.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/views/service/PostViewCountService.java
@@ -1,0 +1,19 @@
+package io.blog.devlog.domain.views.service;
+
+import io.blog.devlog.domain.views.dto.ResponsePostViewCountDto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface PostViewCountService {
+    void increaseViewCount(Long postId);
+    LocalDate parseDate(String date);
+    LocalDate parseStartMonth(String month);
+    LocalDate parseEndMonth(String month);
+    LocalDate parseStartYear(String year);
+    LocalDate parseEndYear(String year);
+
+    List<ResponsePostViewCountDto> getDailyPostViewCount(Long postId, String start, String end);
+    List<ResponsePostViewCountDto> getMonthlyPostViewCount(Long postId, String start, String end);
+    List<ResponsePostViewCountDto> getYearlyPostViewCount(Long postId, String start, String end);
+}

--- a/backend/main-service/src/main/java/io/blog/devlog/domain/views/service/PostViewCountServiceImpl.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/domain/views/service/PostViewCountServiceImpl.java
@@ -1,0 +1,126 @@
+package io.blog.devlog.domain.views.service;
+
+import io.blog.devlog.domain.views.dto.ResponsePostViewCountDto;
+import io.blog.devlog.domain.views.model.PostViewCount;
+import io.blog.devlog.domain.views.repository.PostViewCountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class PostViewCountServiceImpl implements PostViewCountService {
+    private final PostViewCountRepository postViewCountRepository;
+
+    @Override
+    public void increaseViewCount(Long postId) {
+        LocalDate now = LocalDate.now();
+        Optional<PostViewCount> postViewCountOptional = postViewCountRepository.findByPostIdAndViewDate(postId, now);
+        PostViewCount postviewCount = null;
+        if (postViewCountOptional.isEmpty()) {
+            postviewCount = new PostViewCount(postId, now, 1);
+        } else {
+            postviewCount = postViewCountOptional.get();
+            postviewCount.increaseViewCount();
+        }
+        postViewCountRepository.save(postviewCount);
+    }
+
+    @Override
+    public LocalDate parseDate(String date) {
+        try {
+            return LocalDate.parse(date);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid date format");
+        }
+    }
+
+    @Override
+    public LocalDate parseStartMonth(String month) {
+        // month format: yyyy-MM
+        List<Integer> splits = Arrays.stream(month.split("-")).map(Integer::parseInt).toList();
+        if (splits.size() != 2) {
+            throw new IllegalArgumentException("Invalid month format");
+        }
+        return LocalDate.of(splits.get(0), splits.get(1), 1);
+    }
+
+    @Override
+    public LocalDate parseEndMonth(String month) {
+        // month format: yyyy-MM
+        List<Integer> splits = Arrays.stream(month.split("-")).map(Integer::parseInt).toList();
+        if (splits.size() != 2) {
+            throw new IllegalArgumentException("Invalid month format");
+        }
+        LocalDate end = LocalDate.of(splits.get(0), splits.get(1), 1);
+        return LocalDate.of(splits.get(0), splits.get(1), end.lengthOfMonth());
+    }
+
+    @Override
+    public LocalDate parseStartYear(String year) {
+        // year format: yyyy
+        try {
+            return LocalDate.of(Integer.parseInt(year), 1, 1);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid year format");
+        }
+    }
+
+    @Override
+    public LocalDate parseEndYear(String year) {
+        try {
+            return LocalDate.of(Integer.parseInt(year), 12, 31);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid year format");
+        }
+    }
+
+    @Override
+    public List<ResponsePostViewCountDto> getDailyPostViewCount(Long postId, String start, String end) {
+        LocalDate startDate = this.parseDate(start);
+        LocalDate endDate = this.parseDate(end);
+
+        if (!endDate.isAfter(startDate)) {
+            throw new IllegalArgumentException("End date must be after start date");
+        }
+        if (startDate.plusMonths(12).isBefore(endDate)) {
+            throw new IllegalArgumentException("The difference between the two dates must be less than 12 months");
+        }
+        List<Object[]> dailyViews = postViewCountRepository.findDailyViews(postId, startDate, endDate);
+        return dailyViews.stream().map(dailyView -> ResponsePostViewCountDto.ofDailyView(postId, dailyView)).toList();
+    }
+
+    @Override
+    public List<ResponsePostViewCountDto> getMonthlyPostViewCount(Long postId, String start, String end) {
+        LocalDate startDate = this.parseStartMonth(start);
+        LocalDate endDate = this.parseEndMonth(end);
+
+        if (!endDate.isAfter(startDate)) {
+            throw new IllegalArgumentException("End date must be after start date");
+        }
+        if (startDate.plusMonths(12).isBefore(endDate)) {
+            throw new IllegalArgumentException("The difference between the two dates must be less than 12 months");
+        }
+        List<Object[]> monthlyViews = postViewCountRepository.findMonthlyViews(postId, startDate, endDate);
+        return monthlyViews.stream().map(monthlyView -> ResponsePostViewCountDto.ofMonthlyView(postId, monthlyView)).toList();
+    }
+
+    @Override
+    public List<ResponsePostViewCountDto> getYearlyPostViewCount(Long postId, String start, String end) {
+        LocalDate startDate = this.parseStartYear(start);
+        LocalDate endDate = this.parseEndYear(end);
+
+        if (!endDate.isAfter(startDate)) {
+            throw new IllegalArgumentException("End date must be after start date");
+        }
+        if (startDate.plusYears(3).isBefore(endDate)) {
+            throw new IllegalArgumentException("The difference between the two dates must be less than 3 years");
+        }
+        List<Object[]> yearlyViews = postViewCountRepository.findYearlyViews(postId, startDate, endDate);
+        return yearlyViews.stream().map(yearlyView -> ResponsePostViewCountDto.ofYearlyView(postId, yearlyView)).toList();
+    }
+}

--- a/backend/main-service/src/main/java/io/blog/devlog/global/exception/GlobalExceptionHandler.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/global/exception/GlobalExceptionHandler.java
@@ -22,6 +22,14 @@ public class GlobalExceptionHandler {
         errorResponse.setResponse(response, status, error, path);
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public void illegalArgumentExceptionHandler(IllegalArgumentException e, HttpServletRequest request, HttpServletResponse response) throws IOException {
+        Integer status = HttpServletResponse.SC_BAD_REQUEST;
+        String error = e.getMessage();
+        String path = request.getRequestURI();
+        errorResponse.setResponse(response, status, error, path);
+    }
+
     @ExceptionHandler(NullJwtException.class)
     public void nullJwtExceptionHandler(NullJwtException e, HttpServletRequest request, HttpServletResponse response) throws IOException {
         Integer status = HttpServletResponse.SC_NO_CONTENT;

--- a/backend/main-service/src/main/java/io/blog/devlog/global/utils/SecurityUtils.java
+++ b/backend/main-service/src/main/java/io/blog/devlog/global/utils/SecurityUtils.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Objects;
+import java.util.Optional;
 
 public class SecurityUtils {
 
@@ -43,18 +44,18 @@ public class SecurityUtils {
         return null;
     }
 
-    public static User getUserEntity() {
+    public static Optional<User> getUserEntity() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null) {
-            return null;
+            return Optional.empty();
         }
 
         Object principal = authentication.getPrincipal();
 
         if (principal instanceof PrincipalDetails) {
-            return ((PrincipalDetails) principal).getUser();
+            return Optional.of(((PrincipalDetails) principal).getUser());
         }
-        return null;
+        return Optional.empty();
     }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,6 +21,7 @@ import { useEffect, useState } from "react";
 import { GetPayload } from "utils/authenticate";
 import Profile from "pages/Profile";
 import { ClockLoader, HashLoader } from "react-spinners";
+import PostStatistics from "pages/PostStatistics";
 
 function App() {
   const [isLoading, setIsLoading] = useState(true);
@@ -94,11 +95,14 @@ function App() {
                       <Route path="/login" element={<Login />} />
                       <Route path="/signup" element={<Signup />} />
                       <Route path="/callback" element={<Callback />} />
-                    </Route>
-                    <Route element={<PrivateRoute role={ROLE_TYPE.USER} />}>
                       <Route path="/editor" element={<Editor />} />
                       <Route path="/profile" element={<Profile />} />
+                      <Route
+                        path="/post/:postUrl/static"
+                        element={<PostStatistics />}
+                      />
                     </Route>
+                    {/* TODO: editor는 내부적으로 따로 권한처리 */}
                     <Route
                       path="/manager"
                       element={<PrivateRoute role={ROLE_TYPE.ADMIN} />}

--- a/frontend/src/api/User.js
+++ b/frontend/src/api/User.js
@@ -90,3 +90,24 @@ export const send_verify_email_api = async (code) => {
       throw error;
     });
 };
+
+export const upload_profile_url_api = async (file, profileUrl) => {
+  const requestBody = {
+    file: file,
+    profileUrl: profileUrl,
+  };
+
+  return await API.post("/profile/picture", requestBody)
+    .then((response) => response)
+    .catch((error) => {
+      throw error;
+    });
+};
+
+export const delete_profile_url_api = async () => {
+  return await API.delete("/profile/picture")
+    .then((response) => response)
+    .catch((error) => {
+      throw error;
+    });
+};

--- a/frontend/src/components/base/comment/Comment.jsx
+++ b/frontend/src/components/base/comment/Comment.jsx
@@ -74,12 +74,14 @@ function Comment({ ...props }) {
         <CommentEditor
           comment={editorComment}
           setComment={setEditorComment}
-          onSave={() =>
+          onSave={(content, files) =>
             uploadCommentHandler({
               postContent: postContent,
               comments: commentsData.comments,
               editorComment: editorComment,
               setEditorComment: setEditorComment,
+              content: content,
+              files: files,
             })
           }
           setUpdater={setUpdater}

--- a/frontend/src/components/base/comment/comments/Comments.jsx
+++ b/frontend/src/components/base/comment/comments/Comments.jsx
@@ -18,7 +18,13 @@ import { authAtom } from "recoil/authAtom";
 import { commentAtom, commentFilesAtom } from "recoil/commentAtom";
 import { postAtom } from "recoil/postAtom";
 
-const CommentReply = ({ rootComment, comments, reply, setReply }) => {
+const CommentReply = ({
+  rootComment,
+  comments,
+  reply,
+  setReply,
+  setUpdater,
+}) => {
   const authDto = useRecoilValue(authAtom);
   const postContent = useRecoilValue(postAtom);
 
@@ -42,15 +48,17 @@ const CommentReply = ({ rootComment, comments, reply, setReply }) => {
                 setReply: setReply,
               })
             }
-            onSave={(files) =>
+            onSave={(content, files) =>
               uploadReplyHandler({
                 postContent: postContent,
                 comments: comments,
                 reply: reply,
                 setReply: setReply,
+                content: content,
                 files: files,
               })
             }
+            setUpdater={setUpdater}
           />
         </Timeline.Body>
       </Timeline.Content>
@@ -206,12 +214,13 @@ const CommentEdit = ({ comment, comments, reply, setReply, setUpdater }) => {
             setReply: setReply,
           })
         }
-        onSave={(files) =>
+        onSave={(content, files) =>
           updateEditHandler({
             comment: comment,
             comments: comments,
             reply: reply,
             setReply: setReply,
+            content: content,
             files: files,
           })
         }
@@ -222,7 +231,6 @@ const CommentEdit = ({ comment, comments, reply, setReply, setUpdater }) => {
 };
 
 const Comments = ({ comments, reply, setReply, setUpdater }) => {
-  // const [content, setContent] = useRecoilState(replyAtom);
   if (!comments) {
     return null;
   }
@@ -254,6 +262,7 @@ const Comments = ({ comments, reply, setReply, setUpdater }) => {
               comments={comments}
               reply={reply}
               setReply={setReply}
+              setUpdater={setUpdater}
             />
           ) : null}
         </div>

--- a/frontend/src/components/base/comment/comments/CommentsHandler.jsx
+++ b/frontend/src/components/base/comment/comments/CommentsHandler.jsx
@@ -18,13 +18,14 @@ const uploadReplyHandler = async ({
   comments,
   reply,
   setReply,
+  content,
   files,
 }) => {
   try {
     const result = await upload_comment_api(
       postContent,
       reply.target.id,
-      reply.content,
+      content, // reply.content,
       files,
       reply.private
     );
@@ -43,13 +44,15 @@ const uploadCommentHandler = async ({
   comments,
   editorComment,
   setEditorComment,
+  content,
+  files,
 }) => {
   try {
     const result = await upload_comment_api(
       postContent,
       0,
-      editorComment.content,
-      editorComment.files,
+      content, // editorComment.content,
+      files, // editorComment.files,
       editorComment.private
     );
     // const comment = result.data;
@@ -121,10 +124,11 @@ const updateEditHandler = async ({
   comments,
   reply,
   setReply,
+  content,
   files,
 }) => {
   try {
-    await edit_comment_api(comment.id, reply.content, files, reply.private);
+    await edit_comment_api(comment.id, content, files, reply.private); // reply.content
     await cancelEditHandler({ reply: reply, setReply: setReply });
     return true;
   } catch (err) {

--- a/frontend/src/components/editor/commentEditor/CommentEditor.jsx
+++ b/frontend/src/components/editor/commentEditor/CommentEditor.jsx
@@ -78,10 +78,10 @@ function CommentEditor({ comment, setComment, onCancel, onSave, setUpdater }) {
     };
     const newFiles = commentFiles.filter((file) => fileFilter(file));
 
-    setComment({ ...comment, content: tempDiv.innerHTML });
+    await setComment({ ...comment, content: tempDiv.innerHTML });
 
     editorInstance.setData("");
-    await onSave(newFiles);
+    await onSave(tempDiv.innerHTML, newFiles);
     await setUpdater((prev) => prev + 1);
   };
 

--- a/frontend/src/components/profile/Profile.jsx
+++ b/frontend/src/components/profile/Profile.jsx
@@ -14,7 +14,7 @@ import {
 } from "./profileItem";
 import { signOutProcess } from "utils/authenticate";
 import { toast } from "react-toastify";
-import { user_profile_api } from "api/User";
+import { delete_profile_url_api, user_profile_api } from "api/User";
 
 function Profile() {
   const fileInputRef = useRef(null);
@@ -59,7 +59,13 @@ function Profile() {
   };
 
   const removeImageHandler = () => {
-    setUserProfile({ ...userProfile, profileUrl: authDto.profileUrl });
+    try {
+      delete_profile_url_api();
+      setAuthDto({ ...authDto, profileUrl: null });
+      setUserProfile({ ...userProfile, profileUrl: null });
+    } catch (error) {
+      toast.error("요청을 처리하는데 실패했습니다.");
+    }
   };
 
   const handleFileChange = (event) => {
@@ -89,6 +95,7 @@ function Profile() {
         imageCrop={imageCrop}
         setImageCrop={setImageCrop}
         setUserProfile={setUserProfile}
+        setAuthDto={setAuthDto}
       />
       <header className="profile-header">
         <div className="profile-info-box">

--- a/frontend/src/components/side/toc/TOC.jsx
+++ b/frontend/src/components/side/toc/TOC.jsx
@@ -12,7 +12,7 @@ import {
 } from "react-icons/hi";
 import { toast } from "react-toastify";
 import { PostContext, postContextAtom } from "recoil/editorAtom";
-import { delete_post_api, get_post_files_api } from "api/Posts";
+import { delete_post_api } from "api/Posts";
 import { useNavigate } from "react-router-dom";
 import { POST_STORE } from "api/Cache";
 import tocbot from "tocbot";
@@ -37,15 +37,8 @@ const exportUrlHandler = (postContent) => {
   toast.info("URL이 복사되었습니다.", { position: "bottom-center" });
 };
 
+// TODO: 게시글 수정은 /editor/{url} 형태로 새로고침해도 유지되도록 변경
 const postEditHandler = async (navigate, postContent, setPostContext) => {
-  // let files = [];
-  // try {
-  //   const result = await get_post_files_api(postContent.id);
-  //   files = result.data;
-  // } catch (error) {
-  //   console.error("Failed to get post files:", error);
-  // }
-
   const preview = postContent.files.find(
     (file) =>
       `${process.env.REACT_APP_API_FILE_URL}/${file.filePath}/${file.fileUrl}` ===

--- a/frontend/src/pages/PostStatistics.jsx
+++ b/frontend/src/pages/PostStatistics.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import PageTemplate from "components/common/pageTemplate";
+import HeaderContainer from "containers/base/HeaderContainer";
+
+function PostStatistics() {
+  return (
+    <PageTemplate>
+      <HeaderContainer />
+    </PageTemplate>
+  );
+}
+
+export default PostStatistics;


### PR DESCRIPTION
## 프로필 사진 업로드

- 이제 프로필 페이지에서 사진을 선택할 경우, 백엔드 서버에 업로드되어 url을 얻음.
- 이미지 삭제 버튼을 클릭하면, 백엔드 서버에서도 등록된 사진이 삭제되고 url이 null로 변경.

## 조회수 집계를 위한 테이블 추가

- ViewCount라고 명명, 하루를 기준으로 View가 카운팅됨.
- start, end date를 입력 받아서 두 날짜의 간격에 제한을 두어 DB에 무리가 가지 않게 함.
- 추후 GC로 오래된 데이터를 삭제처리하기.

## 버그 픽스

1. 댓글 에디터에서 코드 하이라이팅이 적용되지 않는 문제 수정

## Branch 기능별 분리

- 하나의 기능을 구현하고 끝을 내야하는데 이것저것 일을 늘림.
- 그렇다보니 PR을 날릴 때도 제목을 짓기 애매한게 기능 추가, 버그 픽스 등 혼합되어 합치게 됨.
- 브랜치로 뭘 할지 확실히 구분해서 처리하고 devlop에 합치는 방식으로 해보기.