### PR TITLE
ci/cd: Add frontend deployment pipeline for self-hosted arm64

### DIFF
--- a/.github/workflows/frontend_main_cd.yml
+++ b/.github/workflows/frontend_main_cd.yml
@@ -11,38 +11,21 @@ on:
 permissions: write-all
 
 env:
-  ZIP_NAME: "frontend.zip"
+  ZIP_NAME: "frontend.tar"
   APP_TARGET_PATH: "frontend/"
   APP_FOLDER_PATH: "/home/app/frontend"
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, ARM64]
     defaults:
       run:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          install: true # Buildx를 설치
-
-      - name: Set up Docker Buildx for ARM64
-        run: |
-          docker buildx create --use --platform linux/arm64
-
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Build ARM64 Docker image
-        run: docker buildx build --platform linux/arm64 -f Dockerfile.prod -t devlog-frontend:latest . --load
+        run: docker build -f Dockerfile.prod -t devlog-frontend:latest .
 
       - name: Save Docker image as tar file
         run: docker save -o frontend.tar devlog-frontend:latest
@@ -51,7 +34,7 @@ jobs:
       - name: Modify permissions
         run: chmod o+rwx ${{ env.ZIP_NAME }}
 
-      - name: Send build file
+      - name: Send docker image file
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.SERVER_HOST }}
@@ -61,7 +44,7 @@ jobs:
           target: ${{ env.APP_FOLDER_PATH }}
           strip_components: 1
 
-      - name: Restart Server
+      - name: Start frontend server
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.SERVER_HOST }}
@@ -69,6 +52,5 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             cd ${{ env.APP_FOLDER_PATH }}
-            docker load -i frontend.tar
-            cd /home/app
-            docker-compose -f docker-compose.prod.yml up -d frontend-service
+            docker load -i ${{ env.ZIP_NAME}}
+            docker run -d -p 3000:3000 --name frontend-service devlog-frontend:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,6 @@ networks:
     driver: bridge
 
 services:
-  frontend-service:
-    build: ./frontend
-    ports:
-      - "3000:3000"
-    networks:
-      - ms-network
-
   discovery-service:
     build: ./backend/discovery-service
     ports:

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -34,3 +34,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.idea

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "prettier.printWidth": 100,
+  "prettier.tabWidth": 2,
+  "prettier.useTabs": false,
+  "prettier.semi": true,
+  "prettier.singleQuote": false,
+  "prettier.trailingComma": "es5",
+  "prettier.quoteProps": "as-needed",
+  "prettier.arrowParens": "always",
+  "prettier.bracketSpacing": true,
+  "prettier.singleAttributePerLine": true // 여러 속성을 가진 JSX 요소의 각 속성을 개행할지 여부를 지정합니다.
+}

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
-  output: "standalone",
+  // output: "standalone",
 };
 
 export default nextConfig;

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
-  // output: "standalone",
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -6,6 +6,8 @@ import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useRecoilState } from "recoil";
 import { ETC_STORE } from "./cache";
+import { warnSignOut } from "@/utils/authenticate";
+import { jwt_refresh_api } from "@/api/user";
 
 const REFRESH_URL = "/reissue";
 
@@ -38,15 +40,15 @@ const responseRejectHandler = async (err, navigate, authDto, setAuthDto) => {
 
   const signOutToast = mem(
     async (message, path) => {
-      warnSignOut(setAuthDto, message);
-      navigate(path);
+      await warnSignOut(setAuthDto, message);
+      navigate.push(path);
     },
     { maxAge: 5, cache: ETC_STORE }
   );
 
   if (config.url === REFRESH_URL) {
     if (900 <= status && status <= 999)
-      await signOutToast("다시 로그인을 해주세요.", "/login", navigate);
+      await signOutToast("다시 로그인을 해주세요.", "/login");
     return Promise.reject(err);
   }
 

--- a/frontend/src/app/post/[postUrl]/page.js
+++ b/frontend/src/app/post/[postUrl]/page.js
@@ -2,29 +2,31 @@ import PageTemplate from "@/components/common/pageTemplate";
 import HeaderContainer from "@/containers/base/HeaderContainer";
 import PostContainer from "@/containers/post/PostContainer";
 
-export async function generateMetadata({ params, searchParams }, parent) {
-  const { postUrl } = params;
-  const metadata = {
+const DEFAULT_METADATA = {
+  title: "존재하지 않는 글입니다.",
+  description: "존재하지 않는 글입니다.",
+  keywords: [],
+  author: [], // {name: "이름", url: "주소"}
+  openGraph: {
     title: "존재하지 않는 글입니다.",
     description: "존재하지 않는 글입니다.",
-    keywords: [],
-    author: [], // {name: "이름", url: "주소"}
-    openGraph: {
-      title: "존재하지 않는 글입니다.",
-      description: "존재하지 않는 글입니다.",
-      url: `${process.env.NEXT_PUBLIC_BASE_URL}/post/${postUrl}`,
-      siteName: "devLog",
-      images: [],
-      locale: "ko_KR",
-      type: "website",
-    },
-  };
+    url: "",
+    siteName: "devLog",
+    images: [],
+    locale: "ko_KR",
+    type: "website",
+  },
+};
+
+export async function generateMetadata({ params, searchParams }, parent) {
+  const { postUrl } = params;
+  const metadata = structuredClone(DEFAULT_METADATA);
+  metadata.openGraph.url = `${process.env.NEXT_PUBLIC_BASE_URL}/post/${postUrl}`;
   try {
     const post_metadata = await fetch(
       `${process.env.NEXT_PUBLIC_API_ENDPOINT}/main/posts/${postUrl}/metadata`,
       { next: { revalidate: 3600 } }
     ).then((res) => res.json());
-    // const post_metadata = await get_post_metadata_api(postUrl);
     metadata.title = post_metadata.title;
     metadata.openGraph.title = post_metadata.title;
     metadata.description = post_metadata.description;

--- a/frontend/src/utils/CredentialProvider.js
+++ b/frontend/src/utils/CredentialProvider.js
@@ -1,0 +1,56 @@
+﻿import { useRecoilState } from "recoil";
+import { Auth, authAtom } from "@/recoil/authAtom";
+import { useEffect } from "react";
+import {
+  has_jwt_cookie_api,
+  jwt_refresh_api,
+  user_profile_api,
+} from "@/api/user";
+import { signOutProcess } from "@/utils/authenticate";
+
+export default function CredentialProvider({ children }) {
+  const [authDto, setAuthDto] = useRecoilState(authAtom);
+
+  useEffect(() => {
+    const checkUserdata = async () => {
+      if (authDto?.isLogin) return;
+      try {
+        const jwt = await has_jwt_cookie_api();
+        if (!jwt) return;
+        await jwt_refresh_api();
+        const result = await user_profile_api();
+        const payload = result.data;
+
+        if (result.status === 200) {
+          setAuthDto(
+            new Auth(
+              payload.username,
+              payload.email,
+              true,
+              payload.role,
+              payload.profileUrl,
+              payload.provider,
+              payload.certificate
+            )
+          );
+        } else if (result.status === 204) {
+          return;
+        }
+      } catch (error) {
+        if (error?.message === "Network Error") {
+          console.error("server maintenance:", error);
+          // setMaintenance(true);
+          return;
+        }
+        await signOutProcess(setAuthDto);
+        // await warnSignOut(setAuthDto, "로그인이 만료되었습니다.");
+        return;
+      }
+    };
+
+    checkUserdata();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return <>{children}</>;
+}

--- a/frontend/src/utils/NextProvider.js
+++ b/frontend/src/utils/NextProvider.js
@@ -6,6 +6,7 @@ import { RecoilRoot } from "recoil";
 import NextPostProcesser from "./NextPostProcesser";
 import ClientToastContainer from "./ToastContainer";
 import { AxiosProvider } from "@/api/axios";
+import CredentialProvider from "@/utils/CredentialProvider";
 
 export default function NextProvider({ children }) {
   return (
@@ -13,8 +14,10 @@ export default function NextProvider({ children }) {
       <CookiesProvider>
         <NextThemeProvider>
           <AxiosProvider>
-            <ClientToastContainer />
-            <NextPostProcesser>{children}</NextPostProcesser>
+            <CredentialProvider>
+              <ClientToastContainer />
+              <NextPostProcesser>{children}</NextPostProcesser>
+            </CredentialProvider>
           </AxiosProvider>
         </NextThemeProvider>
       </CookiesProvider>

--- a/frontend/src/utils/NextThemeProvider.js
+++ b/frontend/src/utils/NextThemeProvider.js
@@ -1,14 +1,12 @@
 "use client";
 import { ThemeProvider } from "next-themes";
 import { useEffect } from "react";
-import { GetPayload } from "./authenticate";
 import { put_blog_visit_api } from "@/api/info";
 import { useRecoilState } from "recoil";
 import { renderAtom } from "@/recoil/renderAtom";
 
 export default function NextThemeProvider({ children, ...props }) {
   const [render, setRender] = useRecoilState(renderAtom);
-  GetPayload();
 
   useEffect(() => {
     setRender(true);

--- a/frontend/src/utils/authenticate.jsx
+++ b/frontend/src/utils/authenticate.jsx
@@ -1,15 +1,8 @@
 "use client";
-import { Auth, authAtom } from "@/recoil/authAtom";
-import { useRecoilState } from "recoil";
+import { Auth } from "@/recoil/authAtom";
 import { toast } from "react-toastify";
 import { clearAllCacheStore } from "@/api/cache";
-import { useEffect } from "react";
-import {
-  has_jwt_cookie_api,
-  jwt_refresh_api,
-  user_logout_api,
-  user_profile_api,
-} from "@/api/user";
+import { user_logout_api, user_profile_api } from "@/api/user";
 
 export const signIn = async (setAuthDto, message = "로그인 성공!") => {
   try {
@@ -59,53 +52,4 @@ export const warnSignOut = async (
   if (await signOutProcess(setAuthDto)) {
     toast.warning(`${message}`, {});
   }
-};
-
-export const GetPayload = (setIsLoading = null, setMaintenance = null) => {
-  const [authDto, setAuthDto] = useRecoilState(authAtom);
-
-  useEffect(() => {
-    const checkUserdata = async () => {
-      if (authDto?.isLogin) return;
-      try {
-        const jwt = await has_jwt_cookie_api();
-        if (!jwt) return;
-        await jwt_refresh_api();
-        const result = await user_profile_api();
-        const payload = result.data;
-
-        if (result.status === 200) {
-          setAuthDto(
-            new Auth(
-              payload.username,
-              payload.email,
-              true,
-              payload.role,
-              payload.profileUrl,
-              payload.provider,
-              payload.certificate
-            )
-          );
-        } else if (result.status === 204) {
-          return;
-        }
-      } catch (error) {
-        if (error?.message === "Network Error") {
-          console.error("server maintenance:", error);
-          // setMaintenance(true);
-          return;
-        }
-        await signOutProcess(setAuthDto);
-        // await warnSignOut(setAuthDto, "로그인이 만료되었습니다.");
-        return;
-      } finally {
-        // setIsLoading(false);
-      }
-    };
-
-    checkUserdata();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  return authDto;
 };


### PR DESCRIPTION
# frontend

- 프론트엔드 서버를 배포하기 위해, self-hosted를 통한 arm64 아키텍처 배포 추가.
- responseRejectHandler에서 몇몇 함수가 import되지 않은채 코드가 사용되었던 버그 수정.
- authenticate에서 유저 로그인 정보를 위한 함수를 따로 분리 (CredentialProvider.js)